### PR TITLE
Add option to force a redirect

### DIFF
--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -43,6 +43,7 @@ plugin.tx_rlmplanguagedetection_pi1 {
 
 	testOrder = browser,ip
 	dieAtEnd = 0
+	forceRedirect = 0
 }
 
 # Disable USER_INT when GP:L exists, and the extension anyway isn't needed.

--- a/pi1/class.tx_rlmplanguagedetection_pi1.php
+++ b/pi1/class.tx_rlmplanguagedetection_pi1.php
@@ -290,7 +290,7 @@ class tx_rlmplanguagedetection_pi1 extends tslib_pibase {
 		if (TYPO3_DLOG) {
 			\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('Location to redirect to: ' . $locationURL, $this->extKey);
 		}
-		if (!$this->conf['dieAtEnd'] && $preferredLanguageOrPageUid != 0) {
+		if (!$this->conf['dieAtEnd'] && ($preferredLanguageOrPageUid != 0 || $this->conf['forceRedirect'])) {
 			if (TYPO3_DLOG) {
 				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('Perform redirect', $this->extKey);
 			}


### PR DESCRIPTION
See bug report at https://forge.typo3.org/issues/43772

Add an option to force a redirect if the detected language is the default language. Forcing a redirect may be reasonable if an extension like RealUL is used and the default language shall be show in the URL.
