### PR TITLE
[BUGFIX] Use official vendor of static info tables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   ],
   "require": {
     "typo3/cms": ">6.2",
-    "typo3-ter/static-info-tables": ">6.3"
+    "sjbr/static-info-tables": ">6.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Using the typo3-ter confuses composer and leads to the problem
https://forge.typo3.org/issues/80408