### PR TITLE
[BUGFIX] Redirect when language GET param is empty

### DIFF
--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -83,7 +83,8 @@ class LanguageDetection extends AbstractPlugin
         }
 
         // Break out if language already selected
-        if (!$this->conf['dontBreakIfLanguageIsAlreadySelected'] && GeneralUtility::_GP($this->conf['languageGPVar']) !== null && GeneralUtility::_GP($this->conf['languageGPVar']) !== '') {
+        if (!$this->conf['dontBreakIfLanguageIsAlreadySelected'] 
+            && (GeneralUtility::_GP($this->conf['languageGPVar']) !== null || GeneralUtility::_GP($this->conf['languageGPVar']) !== '')) {
             if (TYPO3_DLOG) {
                 GeneralUtility::devLog('Break out since language is already selected', $this->extKey);
             }

--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -83,7 +83,7 @@ class LanguageDetection extends AbstractPlugin
         }
 
         // Break out if language already selected
-        if (!$this->conf['dontBreakIfLanguageIsAlreadySelected'] && GeneralUtility::_GP($this->conf['languageGPVar']) !== null) {
+        if (!$this->conf['dontBreakIfLanguageIsAlreadySelected'] && GeneralUtility::_GP($this->conf['languageGPVar']) !== null && GeneralUtility::_GP($this->conf['languageGPVar']) !== '') {
             if (TYPO3_DLOG) {
                 GeneralUtility::devLog('Break out since language is already selected', $this->extKey);
             }


### PR DESCRIPTION
This fixes the following issue : if L is set but is empty ("L=" in the query string), language redirection is not performed.

A case where it might happen : on our websites realurl generates URLs for the default language with both "/en/" (corresponds to L=0) and "/" (undefined L) at the beginning. So we created canonical links to avoid duplicates entry in search engines... We had to create a link to the current page with an empty L param through `typolink.additionalParams = &L=`, to override the config.linkVars param (cf. [this core issue](https://forge.typo3.org/issues/35069)). This results in a realurl cache entry with empty L param, so when visiting again the same page without "/en/" at the beginning, language redirection is not triggered.
This is quite a sophisticated situation, but there might be others like this ?