### PR TITLE
Fix IP for Proxies & check if country code has been set before transforming to lowercase

### DIFF
--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -542,6 +542,14 @@ class LanguageDetection extends AbstractPlugin
      */
     protected function getUserIP():string
     {
+        if ($ip = GeneralUtility::getIndpEnv('HTTP_CLIENT_IP')) {
+            return $ip;
+        }
+
+        if ($ip = GeneralUtility::getIndpEnv('HTTP_X_FORWARDED_FOR')) {
+            return $ip;
+        }
+
         return GeneralUtility::getIndpEnv('REMOTE_ADDR');
     }
 

--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -542,15 +542,7 @@ class LanguageDetection extends AbstractPlugin
      */
     protected function getUserIP():string
     {
-        if ($ip = GeneralUtility::getIndpEnv('HTTP_CLIENT_IP')) {
-            return $ip;
-        }
-
-        if ($ip = GeneralUtility::getIndpEnv('HTTP_X_FORWARDED_FOR')) {
-            return $ip;
-        }
-
-        return GeneralUtility::getIndpEnv('REMOTE_ADDR');
+        return GeneralUtility::getIndpEnv('HTTP_CLIENT_IP') || GeneralUtility::getIndpEnv('HTTP_X_FORWARDED_FOR') || GeneralUtility::getIndpEnv('REMOTE_ADDR');
     }
 
     /**

--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -263,13 +263,15 @@ class LanguageDetection extends AbstractPlugin
                         if (TYPO3_DLOG) {
                             GeneralUtility::devLog('IP: ' . $this->getUserIP(), $this->extKey);
                         }
-                        $countryCode = strtolower(geoip_country_code_by_name($this->getUserIP()));
+                        $countryCode = geoip_country_code_by_name($this->getUserIP());
                         if (TYPO3_DLOG) {
                             GeneralUtility::devLog('GeoIP Country Code: ' . $countryCode, $this->extKey);
                         }
                     }
 
                     if ($countryCode) {
+                        $countryCode = strtolower($countryCode);
+
                         //Check for the country code in the configured list of country to languages
                         if (array_key_exists($countryCode, $this->conf['countryCodeToLanguageCode.'])
                             && array_key_exists($this->conf['countryCodeToLanguageCode.'][$countryCode], $availableLanguagesArr)


### PR DESCRIPTION
Hey!

I've had an issue with serving TYPO3 through a proxy. I've extended the code to retrieve the IP from proxy headers. 

Just so you know: HTTP_CLIENT_IP can bet set by the client HTTP_X_FORWARDED_FOR and be manipulated. But as this IP is used to determine the country it shouldn't be security related.

Bonus: When geoip can't find a country code, strtolower throws an error. I moved the strtolower call to a place where $countryCode has to be set.

Cheers ✌️
Hans